### PR TITLE
enable stretch factor for rectangular layout

### DIFF
--- a/lib/src/bubble_chart.dart
+++ b/lib/src/bubble_chart.dart
@@ -83,15 +83,28 @@ class BubbleChart {
 
     // Calculate the extra space after scaling.
     // TODO: Make this for vertical and horizontal
-    double extraSpace = size.width - (xmax - xmin) * scale;
 
-    for (final circle in circles) {
+    if (scaleX < scaleY) {
+      final extraVerticalSpace = size.height - (ymax - ymin) * scale;
       // Translate, scale the x and y coordinates, and center align.
-      circle.x = (circle.x! - xmin) * scale + extraSpace / 2;
-      circle.y = (circle.y! - ymin) * scale;
+      for (final circle in circles) {
+        circle.x = (circle.x! - xmin) * scale;
+        circle.y = (circle.y! - ymin) * scale + extraVerticalSpace / 2;
 
-      // Scale the radius.
-      circle.radius = circle.radius! * scale;
+        // Scale the radius.
+        circle.radius = circle.radius! * scale;
+      }
+    } else {
+      final extraHorizontalSpace = size.width - (xmax - xmin) * scale;
+
+      // Translate, scale the x and y coordinates, and center align.
+      for (final circle in circles) {
+        circle.x = (circle.x! - xmin) * scale + extraHorizontalSpace / 2;
+        circle.y = (circle.y! - ymin) * scale;
+
+        // Scale the radius.
+        circle.radius = circle.radius! * scale;
+      }
     }
   }
 

--- a/lib/src/bubble_chart.dart
+++ b/lib/src/bubble_chart.dart
@@ -39,8 +39,9 @@ class BubbleChart {
         ..leaves.forEach(_radiusLeaf(_defaultRadius))
         ..eachAfter(_packChildren(1, 0))
         ..eachAfter(_packChildren(root.radius! / min(size.width, size.height)))
-        ..eachBefore(
-            _translateChild(min(size.width, size.height) / (2 * root.radius!)));
+        ..eachBefore(_translateChild(
+            min(size.width, size.height * sqrt(stretchFactor)) /
+                (2 * root.radius!)));
     }
   }
 

--- a/lib/src/bubble_chart.dart
+++ b/lib/src/bubble_chart.dart
@@ -8,6 +8,8 @@ class BubbleChart {
   final BubbleNode root;
   final Size size;
   final double Function(BubbleNode)? radius;
+  // Stretch factor determines the width:height ratio of the chart
+  final double stretchFactor;
 
   List<BubbleNode> get leaves {
     return root.leaves;
@@ -21,6 +23,7 @@ class BubbleChart {
     required this.root,
     required this.size,
     this.radius,
+    this.stretchFactor = 1.0,
   })  : assert(root.children != null && root.children!.length > 0),
         assert(size.width > 0 && size.height > 0) {
     root.x = size.width / 2;
@@ -218,7 +221,7 @@ class BubbleChart {
         ab = a.radius! + b.radius!,
         dx = (a.x! * b.radius! + b.x! * a.radius!) / ab,
         dy = (a.y! * b.radius! + b.y! * a.radius!) / ab;
-    return dx * dx + dy * dy;
+    return dx * dx + dy * dy * stretchFactor;
   }
 
   BubbleNodeBase? _enclose(List<BubbleNodeBase> children) {

--- a/lib/src/bubble_chart.dart
+++ b/lib/src/bubble_chart.dart
@@ -32,9 +32,7 @@ class BubbleChart {
     if (root.children != null) {
       root..leaves.forEach(_radiusLeaf(_defaultRadius));
       _packEnclose(root.children!);
-      print(root.children);
       _translateAndScale(root.children!);
-      print(root.children);
     }
 
     // if (radius != null) {

--- a/lib/src/bubble_chart.dart
+++ b/lib/src/bubble_chart.dart
@@ -8,8 +8,7 @@ class BubbleChart {
   final BubbleNode root;
   final Size size;
   final double Function(BubbleNode)? radius;
-  // Stretch factor determines the width:height ratio of the chart
-  final double stretchFactor;
+  final bool isBubbleApp;
 
   List<BubbleNode> get leaves {
     return root.leaves;
@@ -23,7 +22,7 @@ class BubbleChart {
     required this.root,
     required this.size,
     this.radius,
-    this.stretchFactor = 1.0,
+    this.isBubbleApp = true,
   })  : assert(root.children != null && root.children!.length > 0),
         assert(size.width > 0 && size.height > 0) {
     root.x = size.width / 2;
@@ -33,6 +32,17 @@ class BubbleChart {
       root..leaves.forEach(_radiusLeaf(_defaultRadius));
       _packEnclose(root.children!);
       _translateAndScale(root.children!);
+    }
+
+    // In 2 Child case, we want it to be top aligned in the app
+    // Do it only in our phone app
+    if (root.children?.length == 2 && !isBubbleApp) {
+      _moveChildrenToTop(root.children!);
+    }
+
+    // In 4 Child case, we want to rotate 90
+    if (root.children?.length == 4) {
+      _rotateSideways(root.children!);
     }
 
     // if (radius != null) {
@@ -426,6 +436,30 @@ class BubbleChart {
 
     // If we get here then something is very wrong.
     throw new Error();
+  }
+
+  // Change the y coordinate of the bubbles so that it's aligned to
+  // top instead of center
+  void _moveChildrenToTop(List<BubbleNode> circles) {
+    circles.forEach((circle) {
+      circle.y = circle.radius;
+    });
+  }
+
+  /// To rotate about a point (cx, cy) we've to
+  /// Translate by (-cx, -cy)
+  /// Rotate (x, y) -> (-y, x)
+  /// Translate by (cx, cy)
+  /// This has been condensed in the code below
+  void _rotateSideways(List<BubbleNode> circles) {
+    final cx = root.x!;
+    final cy = root.y!;
+
+    circles.forEach((circle) {
+      final tempX = circle.x!;
+      circle.x = -circle.y! + cx + cy;
+      circle.y = tempX - cx + cy;
+    });
   }
 }
 

--- a/lib/src/bubble_chart_layout.dart
+++ b/lib/src/bubble_chart_layout.dart
@@ -6,14 +6,13 @@ class BubbleChartLayout extends StatelessWidget {
   final List<BubbleNode> children;
   final double Function(BubbleNode)? radius;
   final Duration? duration;
-  // Stretch factor determines the width:height ratio of the chart
-  final double stretchFactor;
+  final bool isbubbleApp;
 
   BubbleChartLayout({
     required this.children,
     this.radius,
     this.duration,
-    this.stretchFactor = 1.0,
+    this.isbubbleApp = true,
   });
 
   @override
@@ -24,7 +23,7 @@ class BubbleChartLayout extends StatelessWidget {
           root: BubbleNode.node(children: children),
           radius: radius,
           size: Size(constraints.maxWidth, constraints.maxHeight),
-          stretchFactor: stretchFactor,
+          isBubbleApp: isbubbleApp,
         );
 
         return Stack(

--- a/lib/src/bubble_chart_layout.dart
+++ b/lib/src/bubble_chart_layout.dart
@@ -6,11 +6,14 @@ class BubbleChartLayout extends StatelessWidget {
   final List<BubbleNode> children;
   final double Function(BubbleNode)? radius;
   final Duration? duration;
+  // Stretch factor determines the width:height ratio of the chart
+  final double stretchFactor;
 
   BubbleChartLayout({
     required this.children,
     this.radius,
     this.duration,
+    this.stretchFactor = 1.0,
   });
 
   @override
@@ -21,6 +24,7 @@ class BubbleChartLayout extends StatelessWidget {
           root: BubbleNode.node(children: children),
           radius: radius,
           size: Size(constraints.maxWidth, constraints.maxHeight),
+          stretchFactor: stretchFactor,
         );
 
         return Stack(

--- a/lib/src/bubble_chart_layout.dart
+++ b/lib/src/bubble_chart_layout.dart
@@ -33,6 +33,7 @@ class BubbleChartLayout extends StatelessWidget {
               ..add(
                 duration == null
                     ? Positioned(
+                        key: node.key,
                         top: node.y! - node.radius!,
                         left: node.x! - node.radius!,
                         width: node.radius! * 2,
@@ -40,6 +41,7 @@ class BubbleChartLayout extends StatelessWidget {
                         child: BubbleLayer(bubble: node),
                       )
                     : AnimatedPositioned(
+                        key: node.key,
                         top: node.y! - node.radius!,
                         left: node.x! - node.radius!,
                         width: node.radius! * 2,

--- a/lib/src/bubble_layer.dart
+++ b/lib/src/bubble_layer.dart
@@ -13,22 +13,23 @@ class BubbleLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ClipRRect(
+      borderRadius: BorderRadius.circular(bubble!.radius! * 2),
+      child: InkResponse(
         borderRadius: BorderRadius.circular(bubble!.radius! * 2),
-        child: InkResponse(
-          borderRadius: BorderRadius.circular(bubble!.radius! * 2),
-          onTap: onTap,
-          child: Container(
-            width: bubble!.radius! * 2,
-            height: bubble!.radius! * 2,
-            decoration: BoxDecoration(
-              border: bubble!.options?.border ?? Border(),
-              color: bubble!.options?.color ?? Theme.of(context).primaryColor,
-              shape: BoxShape.circle,
-            ),
-            child: Center(
-              child: bubble!.options?.child ?? Container(),
-            ),
+        onTap: onTap,
+        child: Container(
+          width: bubble!.radius! * 2,
+          height: bubble!.radius! * 2,
+          decoration: BoxDecoration(
+            border: bubble!.options?.border ?? Border(),
+            color: bubble!.options?.color ?? Theme.of(context).primaryColor,
+            shape: BoxShape.circle,
           ),
-        ));
+          child: Center(
+            child: bubble!.options?.child ?? Container(),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/bubble_node.dart
+++ b/lib/src/bubble_node.dart
@@ -2,6 +2,7 @@ import 'package:bubble_chart/src/bubble_node_base.dart';
 import 'package:flutter/material.dart';
 
 class BubbleNode extends BubbleNodeBase {
+  Key? key;
   num _value = 0;
   List<BubbleNode>? children;
   BubbleOptions? options;
@@ -38,6 +39,7 @@ class BubbleNode extends BubbleNodeBase {
 
   BubbleNode.leaf({
     required num value,
+    this.key,
     this.builder,
     this.options,
   }) : _value = value;


### PR DESCRIPTION
This pull request allows adjusting the overall layout of the bubbles to be oval rather than a circle.
It introduces a stretchFactor argument, which modifies the bubble layout to determine how much to favor horizontal distance  from center over vertical distance.

#### Screenshot Examples
<!-- Drag and drop in your image, then copy and paste the URL into `src` -->

Stretch factors greater than 1 make the width larger than the height by a ratio of sqrt(stretchFactor):height. See Stretch factor of 4 and 16 respectively 
<p>
<img alt="Stretch4" src="https://user-images.githubusercontent.com/10517945/235949329-ed0c9ec5-638f-426d-991d-3e2af77273a8.png"  width="300">
<img alt="Stretch16" src="https://user-images.githubusercontent.com/10517945/235949327-1ae3b466-b7d8-41ed-b182-cef6707c9364.png"  width="300">
</p>

Stretch factors less than 1 make the width smaller than the height by the same ratio. See Stretch factor of 1/4 and 1/16 respectively. 
<p>
<img alt="Stretch1:4"  src="https://user-images.githubusercontent.com/10517945/235949320-080baaf1-2412-41cf-a72c-7c1b64212968.png" width="300">
<img alt="Stretch1:16" src="https://user-images.githubusercontent.com/10517945/235949324-9c1cfe97-738f-4b70-abf5-4c33180e10cb.png"  width="300">
</p>
